### PR TITLE
Fixes an error with Unity 2017.3.1 regarding not found namespace

### DIFF
--- a/Assets/EcsRx/Framework/Extensions/PoolManagerExtensions.cs
+++ b/Assets/EcsRx/Framework/Extensions/PoolManagerExtensions.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Linq;
 using EcsRx.Entities;
 using EcsRx.Pools;
-using UnityEngine.VR.WSA.WebCam;
 
 namespace EcsRx.Extensions
 {


### PR DESCRIPTION
`error CS0234: The type or namespace name 'WSA' does not exist in the namespace 'UnityEngine.VR'. Are you missing an assembly reference?`

Since this namespace is unused in the file, I deleted the using directive.